### PR TITLE
Add handling for webgl context loss

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 /* global window */
 
 import './tests/buffer-tests.js';
+import './tests/contextloss-tests.js';
 import './tests/info-tests.js';
 import './tests/program-tests.js';
 import './tests/renderbuffer-tests.js';

--- a/test/tests/contextloss-tests.js
+++ b/test/tests/contextloss-tests.js
@@ -1,0 +1,46 @@
+import { describe, it } from '../mocha-support.js';
+import { createContext } from '../webgl.js';
+import { MemInfoTracker } from './test-utils.js';
+
+describe('webgl context loss tests', () => {
+  it('test context loss', async () => {
+    const { gl } = createContext();
+    // To enable context restoration we must preventDefault on the context loss event:
+    gl.canvas.addEventListener('webglcontextlost', e => e.preventDefault());
+    const ext = gl.getExtension('WEBGL_lose_context');
+    const tracker = new MemInfoTracker(gl, 'texture');
+
+    // Add a texture
+    const tex1 = gl.createTexture();
+    tracker.addObjects(1);
+    gl.bindTexture(gl.TEXTURE_2D, tex1);
+    const texSize = 32 * 16 * 4;
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 32, 16, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    tracker.addMemory(texSize);
+
+    // Force context loss and wait for event loop to complete
+    ext.loseContext();
+    await delay(1);
+
+    // Verify memory tracking was zeroed out
+    tracker.deleteObjectAndMemory(texSize, 1);
+
+    // Force context restoration and wait for event loop to complete
+    ext.restoreContext();
+    await delay(1);
+
+    // Verify you can still add new things
+    const tex2 = gl.createTexture();
+    tracker.addObjects(1);
+    gl.bindTexture(gl.TEXTURE_2D, tex2);
+    const texSize2 = 64 * 24 * 4;
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 24, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    tracker.addMemory(texSize2);
+  });
+});
+
+async function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
When an augmented WebGL context is lost and then restored, further usage of that context would result in:
- Incorrectly reported memory usage
- WebGL errors due to internally tracked bindings being out of sync with the context

We use this package in our app to gather heuristics for adjusting quality/LOD on the fly. We see transient context loss happen fairly regularly in the wild and we'd like to be able to gracefully recover from it.

Changes in this PR:
- Tracking state is reset upon context loss
- Added unit test
- Extensions objects are no longer cached because new ones will be returned after context loss/restore
- Ensured each context/extension is only augmented once
- Removed unused origFuncs and an unused local const

I've omitted the built webgl-memory.js file from this PR to avoid conflicts.

Thanks in advance!