### PR TITLE
Fix bufferData size when using length parameter

### DIFF
--- a/src/augment-api.js
+++ b/src/augment-api.js
@@ -387,7 +387,9 @@ export function augmentAPI(ctx, nameOfClass, options = {}) {
         throw new Error(`no buffer bound to ${target}`);
       }
       let newSize = 0;
-      if (isBufferSource(src)) {
+      if (length !== undefined) {
+        newSize = length * src.BYTES_PER_ELEMENT;
+      } else if (isBufferSource(src)) {
         newSize = src.byteLength;
       } else if (isNumber(src)) {
         newSize = src;

--- a/src/augment-api.js
+++ b/src/augment-api.js
@@ -387,9 +387,7 @@ export function augmentAPI(ctx, nameOfClass, options = {}) {
         throw new Error(`no buffer bound to ${target}`);
       }
       let newSize = 0;
-      if (length !== undefined) {
-        newSize = length;
-      } else if (isBufferSource(src)) {
+      if (isBufferSource(src)) {
         newSize = src.byteLength;
       } else if (isNumber(src)) {
         newSize = src;

--- a/test/tests/buffer-tests.js
+++ b/test/tests/buffer-tests.js
@@ -46,13 +46,15 @@ describe('buffer tests', () => {
 
     gl.bindBuffer(gl.ARRAY_BUFFER, buf1);
     const data1 = new Float32Array(25);
-    const size1 = 15;
-    gl.bufferData(gl.ARRAY_BUFFER, data1, gl.STATIC_DRAW, 0, size1);
+    const size1 = data1.length * data1.BYTES_PER_ELEMENT;
+    const length1 = data1.length;
+    gl.bufferData(gl.ARRAY_BUFFER, data1, gl.STATIC_DRAW, 0, length1);
     tracker.addMemory(size1);
 
     const data1a = new Uint16Array(37);
-    const size1a = 30;
-    gl.bufferData(gl.ARRAY_BUFFER, data1a, gl.STATIC_DRAW, 0, size1a);
+    const size1a = data1a.length * data1a.BYTES_PER_ELEMENT;
+    const length1a = data1a.length;
+    gl.bufferData(gl.ARRAY_BUFFER, data1a, gl.STATIC_DRAW, 0, length1a);
     tracker.addMemory(size1a - size1);
 
     const buf2 = gl.createBuffer();
@@ -60,8 +62,9 @@ describe('buffer tests', () => {
 
     gl.bindBuffer(gl.ARRAY_BUFFER, buf2);
     const data2 = new Float32Array(55);
-    const size2 = 41;
-    gl.bufferData(gl.ARRAY_BUFFER, data2, gl.STATIC_DRAW, 0, size2);
+    const size2 = data2.length * data2.BYTES_PER_ELEMENT;
+    const length2 = data2.length;
+    gl.bufferData(gl.ARRAY_BUFFER, data2, gl.STATIC_DRAW, 0, length2);
     tracker.addMemory(size2);
 
     gl.deleteBuffer(buf1);

--- a/test/tests/buffer-tests.js
+++ b/test/tests/buffer-tests.js
@@ -46,14 +46,14 @@ describe('buffer tests', () => {
 
     gl.bindBuffer(gl.ARRAY_BUFFER, buf1);
     const data1 = new Float32Array(25);
-    const size1 = data1.length * data1.BYTES_PER_ELEMENT;
-    const length1 = data1.length;
+    const length1 = 15;
+    const size1 = length1 * data1.BYTES_PER_ELEMENT;
     gl.bufferData(gl.ARRAY_BUFFER, data1, gl.STATIC_DRAW, 0, length1);
     tracker.addMemory(size1);
 
     const data1a = new Uint16Array(37);
-    const size1a = data1a.length * data1a.BYTES_PER_ELEMENT;
-    const length1a = data1a.length;
+    const length1a = 30;
+    const size1a = length1a * data1a.BYTES_PER_ELEMENT;
     gl.bufferData(gl.ARRAY_BUFFER, data1a, gl.STATIC_DRAW, 0, length1a);
     tracker.addMemory(size1a - size1);
 
@@ -62,8 +62,8 @@ describe('buffer tests', () => {
 
     gl.bindBuffer(gl.ARRAY_BUFFER, buf2);
     const data2 = new Float32Array(55);
-    const size2 = data2.length * data2.BYTES_PER_ELEMENT;
-    const length2 = data2.length;
+    const length2 = 41;
+    const size2 = length2 * data2.BYTES_PER_ELEMENT;
     gl.bufferData(gl.ARRAY_BUFFER, data2, gl.STATIC_DRAW, 0, length2);
     tracker.addMemory(size2);
 

--- a/webgl-memory.js
+++ b/webgl-memory.js
@@ -737,9 +737,7 @@
           throw new Error(`no buffer bound to ${target}`);
         }
         let newSize = 0;
-        if (length !== undefined) {
-          newSize = length;
-        } else if (isBufferSource(src)) {
+        if (isBufferSource(src)) {
           newSize = src.byteLength;
         } else if (isNumber(src)) {
           newSize = src;

--- a/webgl-memory.js
+++ b/webgl-memory.js
@@ -737,7 +737,9 @@
           throw new Error(`no buffer bound to ${target}`);
         }
         let newSize = 0;
-        if (isBufferSource(src)) {
+        if (length !== undefined) {
+          newSize = length * src.BYTES_PER_ELEMENT;
+        } else if (isBufferSource(src)) {
           newSize = src.byteLength;
         } else if (isNumber(src)) {
           newSize = src;


### PR DESCRIPTION
Buffer size is recorded incorrectly when specifying the length parameter:

`
const ext = gl.getExtension('GMAN_webgl_memory');
const buf = gl.createBuffer();
gl.bindBuffer(gl.ARRAY_BUFFER, buf);
const data = new Float32Array(1);

gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
ext.getMemoryInfo().memory.buffer === 4;  // correct

gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW, 0, 1);
ext.getMemoryInfo().memory.buffer === 1; // incorrect, should be 4
`

This PR multiplies the length by BYTES_PER_ELEMENT to record the real size.
Tests updated also.