### PR TITLE
Adding entry for EXT_sRGB's unsized RGBA type

### DIFF
--- a/src/texture-utils.js
+++ b/src/texture-utils.js
@@ -90,6 +90,9 @@ const RED_INTEGER                  = 0x8D94;
 const RGB_INTEGER                  = 0x8D98;
 const RGBA_INTEGER                 = 0x8D99;
 
+const SRGB_ALPHA_EXT               = 0x8C42;
+
+
 const formatInfo = {};
 {
   // NOTE: this is named `numColorComponents` vs `numComponents` so we can let Uglify mangle
@@ -133,6 +136,7 @@ function getTextureInternalFormatInfo(internalFormat) {
     t[LUMINANCE_ALPHA]    = { bytesPerElement: [2, 4, 4, 8],        type: [UNSIGNED_BYTE, HALF_FLOAT, HALF_FLOAT_OES, FLOAT], };
     t[RGB]                = { bytesPerElement: [3, 6, 6, 12, 2],    type: [UNSIGNED_BYTE, HALF_FLOAT, HALF_FLOAT_OES, FLOAT, UNSIGNED_SHORT_5_6_5], };
     t[RGBA]               = { bytesPerElement: [4, 8, 8, 16, 2, 2], type: [UNSIGNED_BYTE, HALF_FLOAT, HALF_FLOAT_OES, FLOAT, UNSIGNED_SHORT_4_4_4_4, UNSIGNED_SHORT_5_5_5_1], };
+    t[SRGB_ALPHA_EXT]     = { bytesPerElement: [4, 8, 8, 16, 2, 2], type: [UNSIGNED_BYTE, HALF_FLOAT, HALF_FLOAT_OES, FLOAT, UNSIGNED_SHORT_4_4_4_4, UNSIGNED_SHORT_5_5_5_1], };
     t[DEPTH_COMPONENT]    = { bytesPerElement: [2, 4],              type: [UNSIGNED_INT, UNSIGNED_SHORT], };
     t[DEPTH_STENCIL]      = { bytesPerElement: [4],                 };
 


### PR DESCRIPTION
As part of the removal of inline sRGB decode from three.js [here](https://github.com/mrdoob/three.js/pull/23129/files#diff-6bdac4da85be606f09e2ab24b41c761b23ced0d9acaa720e2f2200d938a714e9R1656), this type is the new default for data textures in the WebGL1 fallback mode.

There are additional types defined by [this extension](https://developer.mozilla.org/en-US/docs/Web/API/EXT_sRGB), but they are less common. Mainly, this will help prevent the `unknown internal format` error after a three.js upgrade in projects that still rely on WebGL1.